### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ the range objects supported by `Grid`:
 	where `r1` and `r2` are `NumericRange` objects and `r3` a
 	`NominalRange` object.
 
-Recall that `NominalRange` has a `values` field, while `NominalRange`
+Recall that `NominalRange` has a `values` field, while `NumericRange`
 has the fields `upper`, `lower`, `scale`, `unit` and `origin`. The
 `unit` field specifies a preferred length scale, while `origin` a
 preferred "central value". These default to `(upper - lower)/2` and


### PR DESCRIPTION
Looking at the struct definition in [MLBase.jl](https://github.com/alan-turing-institute/MLJBase.jl/blob/4c9a32d617f4377a40d58b6f7a4dd81b9bf221fb/src/hyperparam/one_dimensional_ranges.jl#L16-L23), I think this was a typo.