### PR TITLE
Update to MLJBase 0.12.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJTuning"
 uuid = "03970b2e-30c4-11ea-3135-d1576263f10f"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"
@@ -12,7 +12,7 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
 ComputationalResources = "^0.3"
-MLJBase = "^0.11"
+MLJBase = "^0.12"
 RecipesBase = "^0.8"
 julia = "^1"
 

--- a/src/ranges.jl
+++ b/src/ranges.jl
@@ -1,6 +1,3 @@
-# TODO: move this next line to MLJBase:
-MLJBase.iterator(r::NominalRange, ::Nothing) = iterator(r)
-
 """
     MLJTuning.grid([rng, ] prototype, ranges, resolutions)
 


### PR DESCRIPTION
- [x] (**breaking**) Update to MLJBase 0.12.0, which changes the position of the optional argument `rng` in `iterator` to first position (https://github.com/alan-turing-institute/MLJBase.jl/issues/215)

~~The source branch in this PR is not synchronised with a tagged release of `MLJBase` but with `MLJBase#early-march`.~~

~~It is expected to fail on travis.~~

Before merging:

- [x] Wait for https://github.com/alan-turing-institute/MLJBase.jl/pull/216 to merge and for MLJBase 0.12.0 to be released. 

- [x] Update [compat] MLJBase="^0.12.0"
