### PR TITLE
For a 0.3.2 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJTuning"
 uuid = "03970b2e-30c4-11ea-3135-d1576263f10f"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"

--- a/README.md
+++ b/README.md
@@ -291,38 +291,42 @@ Grid(; goal=nothing, resolution=10, shuffle=true,
 
 Generally new types are defined for each class of range object a
 tuning strategy should like to handle, and the tuning strategy
-functions to be implemented are dispatched on these types. Here are
-the range objects supported by `Grid`:
+functions to be implemented are dispatched on these types. It is
+recommended that every tuning strategy support at least these types:
 
-  - one-dimensional `NumericRange` or `NominalRange` objects (of
-    abstract type `ParamRange`) provided by MLJBase.
+- one-dimensional ranges `r`, where `r` is a `MLJBase.ParamRange` instance
 
-  - a tuple `(p, r)` where `p` is one of the above range objects, and
-	`r` a resolution to override the default `resolution` of the
-	strategy
+- (optional) pairs of the form `(r, data)`, where `data` is metadata,
+  such as a resolution in a grid search, or a distribution in a random
+  search
 
-  - vectors of objects of the above form, e.g., `[r1, (r2, 5), r3]`
-	where `r1` and `r2` are `NumericRange` objects and `r3` a
-	`NominalRange` object.
+- abstract vectors whose elements are of the above form
 
-Both `NumericRange` and `NominalRange` are constructed with the
-`MLJBase` extension to the `range` function. Use the `iterator` and
-`sampler` methods to convert ranges into one-dimensional grids or for
-random sampling, respectively. See the docstrings for details.
+Recall that `ParamRange` has two concrete subtypes `NumericRange` and
+`NominalRange`, whose instances are constructed with the `MLJBase`
+extension to the `range` function. 
 
-Recall that `NominalRange` has a `values` field, while `NumericRange`
-has the fields `upper`, `lower`, `scale`, `unit` and `origin`. The
-`unit` field specifies a preferred length scale, while `origin` a
-preferred "central value". These default to `(upper - lower)/2` and
-`(upper + lower)/2`, respectively, in the bounded case (neither `upper
-= Inf` nor `lower = -Inf`). The fields `origin` and `unit` are used in
-generating grids or fitting probability distributions to unbounded
-ranges.
+Note in particular that a `NominalRange` has a `values` field, while
+`NumericRange` has the fields `upper`, `lower`, `scale`, `unit` and
+`origin`. The `unit` field specifies a preferred length scale, while
+`origin` a preferred "central value". These default to `(upper -
+lower)/2` and `(upper + lower)/2`, respectively, in the bounded case
+(neither `upper = Inf` nor `lower = -Inf`). The fields `origin` and
+`unit` are used in generating grids or fitting probability
+distributions to unbounded ranges.
 
 A `ParamRange` object is always associated with the name of a
 hyperparameter (a field of the prototype in the context of tuning)
-which is recorded in its `field` attribute, but for composite models
-this might be a be a "nested name", such as `:(atom.max_depth)`.
+which is recorded in its `field` attribute, a `Symbol`, but for
+composite models this might be a be an `Expr`, such as
+`:(atom.max_depth)`.
+
+Use the `iterator` and `sampler` methods to convert ranges into
+one-dimensional grids or for random sampling, respectively. See the
+[tuning
+section](https://alan-turing-institute.github.io/MLJ.jl/dev/tuning_models/#API-1)
+of the MLJ manual or doc-strings for more on these methods and the
+`Grid` and `RandomSearch` implementations.
 
 
 #### The `result` method: For building each entry of the history

--- a/src/range_methods.jl
+++ b/src/range_methods.jl
@@ -31,21 +31,18 @@ the results. Otherwise models are ordered, with the first
 hyperparameter referenced cycling fastest.
 
 """
-grid(rng::AbstractRNG, prototype::Model, ranges, resolutions) =
-    shuffle(rng, grid(prototype, ranges, resolutions))
+grid(rng::AbstractRNG, prototype::Model, fields, iterators) =
+    shuffle(rng, grid(prototype, fields, iterators))
 
-function grid(prototype::Model, ranges, resolutions)
-
-    iterators = broadcast(iterator, ranges, resolutions)
+function grid(prototype::Model, fields, iterators)
 
     A = MLJBase.unwind(iterators...)
 
     N = size(A, 1)
     map(1:N) do i
         clone = deepcopy(prototype)
-        for k in eachindex(ranges)
-            field = ranges[k].field
-            recursive_setproperty!(clone, field, A[i,k])
+        for k in eachindex(fields)
+            recursive_setproperty!(clone, fields[k], A[i,k])
         end
         clone
     end
@@ -57,8 +54,8 @@ end
 """
     process_grid_range(user_specified_range, resolution, verbosity)
 
-Utility to convert a user-specified range (see [`Grid`](@ref)) into a
-pair of tuples `(ranges, resolutions)`.
+Convert a user-specified range (see [`Grid`](@ref)) into a tuple  of
+tuples `(ranges, resolutions)`.
 
 For example, if `r1`, `r2` are `NumericRange`s and `s` is a
 NominalRange` with 5 values, then we have:

--- a/src/strategies/grid.jl
+++ b/src/strategies/grid.jl
@@ -19,8 +19,8 @@ of a `TunedModel` instance can be:
 
 - Any vector of objects of the above form
 
-Two ranges *for the same field* can be combined by simply including
-both ranges in the list, as in Example 3 below. 
+Two elements of a `range` vector may share the same `field` attribute,
+with the effect that their grids are combined, as in Example 3 below.
 
 `ParamRange` objects are constructed using the `range` method.
 

--- a/src/strategies/random_search.jl
+++ b/src/strategies/random_search.jl
@@ -66,7 +66,7 @@ distribution types  | for fitting to ranges of this type
     # uniform sampling of :(atom.λ) from [0, 1] without defining a NumericRange:
     struct MySampler end
     Base.rand(rng::Random.AbstractRNG, ::MySampler) = rand(rng)
-    range3 = (:(atom.λ), MySampler(), range1)
+    range3 = (:(atom.λ), MySampler())
 
 ### Algorithm
 

--- a/test/range_methods.jl
+++ b/test/range_methods.jl
@@ -53,10 +53,15 @@ r2 = range(super_model, :K, lower=1, upper=10, scale=:log10)
 
 @testset "models from cartesian range and resolutions" begin
 
+    f1 = r1.field
+    f2 = r2.field
+    itr1 = iterator(r1, nothing)
+    itr2 = iterator(r2, 7)
+
     # with method:
-    m1 = MLJTuning.grid(super_model, [r1, r2], [nothing, 7])
-    m1r = MLJTuning.grid(MersenneTwister(123), super_model, [r1, r2],
-                         [nothing, 7])
+    m1 = MLJTuning.grid(super_model, [f1, f2], [itr1, itr2])
+    m1r = MLJTuning.grid(MersenneTwister(123), super_model, [f1, f2],
+                         [itr1, itr2])
 
     # generate all models by hand:
     models1 = [SuperModel(1, DummyModel(1.2, 9.5, 'c'), dummy_model),
@@ -76,8 +81,10 @@ r2 = range(super_model, :K, lower=1, upper=10, scale=:log10)
     @test m1r != models1
     @test _issubset(models1, m1r) && _issubset(m1, models1)
 
+    itr1 = iterator(r1, 1)
+
     # with method:
-    m2 = MLJTuning.grid(super_model, [r1, r2], [1, 7])
+    m2 = MLJTuning.grid(super_model, [f1, f2], [itr1, itr2])
 
     # generate all models by hand:
     models2 = [SuperModel(1, DummyModel(1.2, 9.5, 'c'), dummy_model),


### PR DESCRIPTION
- [x] In `Grid` search, allow multiple one-dimensional ranges in a `range` vector to share the same `field` attribute, with the effect that their grids are combined. Allows one to add specific values to automatically generated ones, for example

- [x] Improve docs on subject of implementing Cartesian range objects (#24)