### PR TITLE
fix ambiguous scope warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ julia:
   #- 1.1
   #- 1.2
   #- 1.3
-  - 1.4
+  #- 1.4
+  -  1.5
   - nightly
 matrix:
   allow_failures:

--- a/src/MLJTuning.jl
+++ b/src/MLJTuning.jl
@@ -32,16 +32,15 @@ using ProgressMeter
 
 const DEFAULT_N = 10 # for when `default_n` is not implemented
 
-
 ## INCLUDE FILES
 
 include("utilities.jl")
 include("tuning_strategy_interface.jl")
-include("tuned_models.jl")
-include("range_methods.jl")
 include("strategies/explicit.jl")
 include("strategies/grid.jl")
 include("strategies/random_search.jl")
+include("tuned_models.jl")
+include("range_methods.jl")
 include("plotrecipes.jl")
 include("learning_curves.jl")
 


### PR DESCRIPTION
Although i don't see any reason for the ambiguous assignment in soft scope warning on Julia >= 1.5. This PR fixes https://github.com/alan-turing-institute/MLJ.jl/issues/624 by simply rearranging the `include` statements.