### PR TITLE
Okonsfixes

### DIFF
--- a/src/learning_curves.jl
+++ b/src/learning_curves.jl
@@ -83,8 +83,7 @@ a machine.
 - `rows` - row indices to which resampling should be restricted;
   default is all rows
 
-- `weights` - sample weights used by `measure`; defaults to weights
-  bound to `mach` if these exist
+- `weights` - sample weights used by `measure` where supported
 
 - `operation` - operation, such as `predict`, to be used in
   evaluations. If `prediction_type(mach.model) == :probabilistic` but

--- a/src/tuned_models.jl
+++ b/src/tuned_models.jl
@@ -98,12 +98,6 @@ a score, rather than a loss, be sure to check that
 measure, rather than minimization. Override an incorrect value with
 `MLJ.orientation(::typeof(measure)) = :score`.
 
-*Important:* If `weights` are left unspecified, and `measure` supports
-sample weights, then any weight vector `w` used in constructing a
-corresponding tuning machine, as in `tuning_machine =
-machine(tuned_model, X, y, w)` (which is then used in *training* each
-model in the search) will also be passed to `measure` for evaluation.
-
 In the case of two-parameter tuning, a Plots.jl plot of performance
 estimates is returned by `plot(mach)` or `heatmap(mach)`.
 
@@ -137,9 +131,8 @@ plus others specific to the `tuning` strategy, such as `history=...`.
   strategy is multi-objective) but all reported to the history
 
 - `weights`: sample weights to be passed the measure(s) in performance
-  evaluations, if supported (see important note above for behaviour in
-  unspecified case)
-
+  evaluations, if supported.
+  
 - `repeats=1`: for generating train/test sets multiple times in
   resampling; see [`evaluate!`](@ref) for details
 


### PR DESCRIPTION
This PR updates the docstring for `TunedModel` and `learning_curve` and related models to reflect recent decoupling of training weights from weights when evaluating measures. closes #70 
Wait for https://github.com/alan-turing-institute/MLJBase.jl/pull/409#partial-pull-merging to be merged before merging this
