### PR TITLE
delete multiple inclusion of same file

### DIFF
--- a/src/MLJTuning.jl
+++ b/src/MLJTuning.jl
@@ -40,8 +40,6 @@ const DEFAULT_N = 10 # for when `default_n` is not implemented
 include("utilities.jl")
 include("tuning_strategy_interface.jl")
 include("selection_heuristics.jl")
-include("tuned_models.jl")
-include("range_methods.jl")
 include("strategies/explicit.jl")
 include("strategies/grid.jl")
 include("strategies/random_search.jl")

--- a/src/strategies/explicit.jl
+++ b/src/strategies/explicit.jl
@@ -1,12 +1,11 @@
 mutable struct Explicit <: TuningStrategy end
 
-struct ExplicitState{R,N}
+struct ExplicitState{R, N}
     range::R # a model-generating iterator
     next::N # to hold output of `iterate(range)`
 end
 
-ExplicitState(r::R, ::Nothing) where R = ExplicitState{R,Nothing}(r,nothing)
-ExplictState(r::R, n::N) where {R,N} = ExplicitState{R,Union{Nothing,N}}(r,n)
+ExplictState(r::R, n::N) where {R,N} = ExplicitState{R, Union{Nothing, N}}(r, n)
 
 function MLJTuning.setup(tuning::Explicit, model, range, verbosity)
     next = iterate(range)

--- a/src/strategies/explicit.jl
+++ b/src/strategies/explicit.jl
@@ -1,8 +1,8 @@
 mutable struct Explicit <: TuningStrategy end
 
 struct ExplicitState{R,N}
-    range::R               # a model-generating iterator
-    next::Union{Nothing,N} # to hold output of `iterate(range)`
+    range::R # a model-generating iterator
+    next::N # to hold output of `iterate(range)`
 end
 
 ExplicitState(r::R, ::Nothing) where R = ExplicitState{R,Nothing}(r,nothing)


### PR DESCRIPTION
This PR
1. deletes multiple inclusion of some files in at  *MLJTuning/src/MLJTuning.jl*
2. changes type annotation of next field in `ExplicitState` struct. i.e 
```julia
struct ExplicitState{R,N}
    range::R # a model-generating iterator
    next::Union{Nothing, N} # to hold output of `iterate(range)`
end

ExplicitState(r::R, ::Nothing) where R = ExplicitState{R,Nothing}(r,nothing)
ExplictState(r::R, n::N) where {R,N} = ExplicitState{R,Union{Nothing,N}}(r,n)
```
was replaced by
```julia
struct ExplicitState{R, N}
    range::R # a model-generating iterator
    next::N # to hold output of `iterate(range)`
end

ExplictState(r::R, n::N) where {R,N} = ExplicitState{R, Union{Nothing, N}}(r, n)
```
This was done becase `ExplicitState` is an immutable struct and `Union{Nothing, Nothing}==Nothing`

@ablaom. You could merge this and tag a new release if your satisfied with the second change.