### PR TITLE
Add a model buffer to save surplus models generated by `models`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Distributions = "^0.22,^0.23,^0.24, 0.25"
 LatinHypercubeSampling = "^1.7.2"
 MLJBase = "^0.17.7, ^0.18"
 MLJModelInterface = "^0.4.1, 1.0"
-ProgressMeter = "^1.3"
+ProgressMeter = "^1.7.1"
 RecipesBase = "^0.8,^0.9,^1"
 julia = "^1"
 

--- a/src/strategies/explicit.jl
+++ b/src/strategies/explicit.jl
@@ -12,7 +12,7 @@ function MLJTuning.setup(tuning::Explicit, model, range, n, verbosity)
     return ExplicitState(range, next)
 end
 
-# models! returns all available models in the range at once:
+# models! returns as many models as possible but no more than `n_remaining`:
 function MLJTuning.models(tuning::Explicit,
                            model,
                            history,

--- a/src/strategies/grid.jl
+++ b/src/strategies/grid.jl
@@ -146,19 +146,27 @@ function setup(tuning::Grid, model, user_range, n, verbosity)
 
     state = (models=models,
              fields=fields,
-             parameter_scales=parameter_scales)
+             parameter_scales=parameter_scales,
+             models_delivered=false)
 
     return state
 
 end
 
-MLJTuning.models(tuning::Grid,
-                 model,
-                 history,
-                 state,
-                 n_remaining,
-                 verbosity) =
-                     state.models[_length(history) + 1:end], state
+# models returns all models on first call:
+function MLJTuning.models(tuning::Grid,
+                          model,
+                          history,
+                          state,
+                          n_remaining,
+                          verbosity)
+    state.models_delivered && return nothing, state
+    state = (models=state.models,
+             fields=state.fields,
+             parameter_scales=state.parameter_scales,
+             models_delivered=true)
+    return state.models, state
+end
 
 tuning_report(tuning::Grid, history, state) =
     (plotting = plotting_report(state.fields, state.parameter_scales, history),)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -38,5 +38,3 @@ signature(measure) =
     else
         0
     end
-
-


### PR DESCRIPTION
Currently when `models` generates more models than required (because including them would increase the history length beyond the number of iterations `n` specified at `TunedModel` construction) the surplus models are simply dropped. This leads to wrong behaviour in a ["warm-restart"](https://alan-turing-institute.github.io/MLJ.jl/dev/machines/#Warm-restarts) of tuning.

This PR adds a "model buffer" to fix this behaviour. It also modifies the `Grid` implementation which was working before, but for the "wrong reasons". I don't think any other current strategies are actually effected by the bug but a discussion with @lhnguyen-vn on PSO made me realize the potential for future problems.

I'm including below a relevant section of the updated README for further clarification:

---

#### The `models` method: For generating model batches to evaluate

```julia
MLJTuning.models(tuning::MyTuningStrategy, model, history, state, n_remaining, verbosity)
	-> vector_of_models, new_state
```

This is the core method of a new implementation. Given the existing
`history` and `state`, it must return a vector ("batch") of *new*
model instances `vector_of_models` to be evaluated, and the updated
`state`. Any number of models may be returned (and this includes an
empty vector or `nothing`) and the evaluations will be performed in
parallel (using the mode of parallelization defined by the
`acceleration` field of the `TunedModel` instance).

If more models are returned than needed (because including them would   &nbsp;   <---------- **see here**  in particular
create a history whose length exceeds the user-specified number of
iterations `tuned_model.n`) then the surplus models are saved, for use
in a ["warm restart"](https://alan-turing-institute.github.io/MLJ.jl/dev/machines/#Warm-restarts)
of tuning, when the user increases `tuned_model.n`. The remaining
models are then evaluated and these evaluations are added to the
history. **In any warm restart, no new call to `models` will be made
until all saved models have been evaluated, and these evaluations
added to the history.**

If the tuning algorithm exhausts it's supply of new models (because,
for example, there is only a finite supply, as in a `Grid` search)
then `vector_of_models` should be an empty vector or `nothing`. The
interface has no fixed "batch-size" parameter, and the tuning
algorithm is happy to receive any number of models; a surplus is
handled as explained above, a shortfall will trigger an early stop
(so that the final history has length less than `tuned_model.n`).

If needed, extra metadata may be attached to each model returned; see
[below](#including-model-metadata).

Sequential tuning strategies generating models non-deterministically
(e.g., simulated annealing) might choose to include a batch size
hyperparameter, and arrange that `models` returns batches of the
specified size (to be evaluated in parallel when `acceleration` is set
appropriately). However, the evaluations and history updates do not
occur until after the `models` call, so it may be complicated or
impossible to preserve the original (strictly) sequential algorithm in
that case, which should be clearly documented. 

Some simple tuning strategies, such as `RandomSearch`, will want to
return as many models as possible in one hit. To this end, the
variable `n_remaining` is passed to the `models` call; this is the
difference between the current length of the history and
`tuned_model.n`.


##### Including model metadata

If a tuning strategy implementation needs to record additional
metadata in the history, for each model generated, then instead of
model instances, `vector_of_models` should be vector of *tuples* of the
form `(m, metadata)`, where `m` is a model instance, and `metadata`
the associated data. ***To access the metadata for the `j`th element of
the existing history, use `history[j].metadata`.***



