### PR TITLE
Fix invalid test tripped by julia 1.6.3 (reproducibility issue)

### DIFF
--- a/test/strategies/grid.jl
+++ b/test/strategies/grid.jl
@@ -141,7 +141,7 @@ end
     r = [features_, lambda_]
 
     holdout = Holdout(fraction_train=0.8)
-    grid = Grid(resolution=10)
+    grid = Grid(resolution=10, rng=123)
 
     tuned_model = TunedModel(model=composite, tuning=grid,
                              resampling=holdout, measure=rms,
@@ -152,7 +152,6 @@ end
     fit!(tuned, verbosity=0)
     r = MLJBase.report(tuned)
     @test :model in collect(keys(r.best_report))
-    fit!(tuned, verbosity=0)
     rep = MLJBase.report(tuned)
     fp = fitted_params(tuned)
     @test :model in collect(keys(fp.best_fitted_params))


### PR DESCRIPTION
No need for a new release.

This addresses [a CI fail](https://github.com/JuliaAI/MLJTuning.jl/runs/3853880682?check_suite_focus=true) triggered by the release of julia 1.6.3.