### PR TITLE
Fix a confusing error when forgetting to instantiate models

### DIFF
--- a/src/tuned_models.jl
+++ b/src/tuned_models.jl
@@ -277,8 +277,10 @@ function TunedModel(; model=nothing,
         model = first(range)
         if model isa Deterministic
             M = Deterministic
-        else
+        elseif model isa Probabilistic
             M = Probabilistic
+        else
+            throw(ERR_MODEL_TYPE)
         end
     else
         M = typeof(model)
@@ -287,24 +289,14 @@ function TunedModel(; model=nothing,
     # get the tuning type parameter:
     T = typeof(tuning)
 
+    args = (model, tuning, resampling, measure, weights, operation, range,
+        selection_heuristic, train_best, repeats, n, acceleration, acceleration_resampling,
+        check_measure, cache)
+
     if M <: Deterministic
-        tuned_model = DeterministicTunedModel{T,M}(model, tuning, resampling,
-                                              measure, weights, operation,
-                                              range, selection_heuristic,
-                                              train_best, repeats, n,
-                                              acceleration,
-                                              acceleration_resampling,
-                                              check_measure,
-                                              cache)
+        tuned_model = DeterministicTunedModel{T,M}(args...)
     elseif M <: Probabilistic
-        tuned_model = ProbabilisticTunedModel{T,M}(model, tuning, resampling,
-                                              measure, weights, operation,
-                                              range, selection_heuristic,
-                                              train_best, repeats, n,
-                                              acceleration,
-                                              acceleration_resampling,
-                                              check_measure,
-                                              cache)
+        tuned_model = ProbabilisticTunedModel{T,M}(args...)
     else
         throw(ERR_MODEL_TYPE)
     end

--- a/test/strategies/explicit.jl
+++ b/test/strategies/explicit.jl
@@ -38,6 +38,10 @@ X, y = make_blobs(rng=rng)
     # check scores are the same:
     @test last.(ms) ≈ scores
 
+    # fail with ArgumentError when model types are wrong (e.g., are not instantiated).
+    # this used to throw a very confusing MethodError.
+    dcc = DeterministicConstantClassifier
+    @test_throws ArgumentError TunedModel(; models=[dcc, dcc])
 end
 
 true


### PR DESCRIPTION
There was a mistake in the logic which caused unknown models to be considered as `Probabilistic`.

# Before

```
julia> TunedModel(; models=[LinearModel, TreeModel])
MethodError: Cannot `convert` an object of type Type{MLJLinearModels.LinearRegressor} to an object of type MLJModelInterface.Probabilistic
[...]
```

# After

```
julia>     TunedModel(models=[LinearModel, TreeModel])
ERROR: ArgumentError: Only `Deterministic` and `Probabilistic` model types supported.
[...]
``` 