### PR TITLE
Add link to usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hyperparameter optimization for
 [MLJ](https://github.com/alan-turing-institute/MLJ.jl) machine
 learning models.
 
-See [Tuning Models · MLJ](https://alan-turing-institute.github.io/MLJ.jl/dev/tuning_models) for usage examples.
+See [**Tuning Models · MLJ**](https://alan-turing-institute.github.io/MLJ.jl/dev/tuning_models) for usage examples.
 
 [![Build Status](https://github.com/JuliaAI/MLJTuning.jl/workflows/CI/badge.svg)](https://github.com/JuliaAI/MLJTuning.jl/actions)
 [![codecov.io](http://codecov.io/github/JuliaAI/MLJTuning.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaAI/MLJTuning.jl?branch=master)


### PR DESCRIPTION
Some Julia users will end up at this repository when searching for Grid search or other ways to tune models. This PR adds a link to usage examples at the top of the README as is normally the case for Julia packages.