### PR TITLE
Declutter display of hyper-parameter labels in plots

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,10 +1,14 @@
+const MAX_AXIS_LABEL_WIDTH = 20
+
 @recipe function f(mach::MLJBase.Machine{<:EitherTunedModel})
     rep = report(mach)
     measurement = repr(rep.best_history_entry.measure[1])
     r = rep.plotting
     z = r.measurements
     X = r.parameter_values
-    guides = r.parameter_names
+    guides = map(r.parameter_names) do name
+        trim(name, MAX_AXIS_LABEL_WIDTH)
+    end 
     scales = r.parameter_scales
     n = size(X, 2)
     indices = LinearIndices((n, n))'

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -39,3 +39,22 @@ signature(measure) =
     else
         0
     end
+
+# function to trim a string like "transformed_target_model_deterministic.model.K" to `N`
+# characters. For example, if `N=20`, return `…model.K`. Used in plotrecipes.jl.
+function trim(str, N)
+    n = length(str)
+    n <= N && return str
+    fits = false
+    parts = split(str, ".") |> reverse
+    # removes parts until what remains fits, with room for ellipsis (1 character), or if
+    # there is only one part left:
+    while !fits && length(parts) > 1
+        removed = pop!(parts)
+        n -= length(removed) + 1 # the `1` is for the dot, `.`
+        if n < N
+            fits = true
+        end
+    end
+    "…"*join(reverse(parts), ".")
+end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -22,5 +22,16 @@ end
     @test MLJTuning.signature.(measures) == [-1, 0, 1]
 end
 
+@testset "trim" begin
+    str = "some.long.name" # 14 characters
+    @test MLJTuning.trim(str, 14) == str
+    @test MLJTuning.trim(str, 13) == "…long.name" # 10 characters
+    @test MLJTuning.trim(str, 12) == "…long.name"
+    @test MLJTuning.trim(str, 11) == "…long.name"
+    @test MLJTuning.trim(str, 10) == "…long.name"
+    @test MLJTuning.trim(str, 9) == "…name"
+    @test MLJTuning.trim(str, 1) == "…name" # cannot go any smaller
+end
+
 true
 


### PR DESCRIPTION
When tuning deeply nested hyper-parameters, the plots get horribly cluttered.

# Before this PR:

<img width="838" height="786" alt="Screenshot 2025-12-09 at 5 23 44 PM" src="https://github.com/user-attachments/assets/e153216b-9ac9-4779-9a42-204e913db1a6" />


# After this PR:


<img width="834" height="802" alt="Screenshot 2025-12-09 at 5 17 28 PM" src="https://github.com/user-attachments/assets/5a9d9527-12ff-4369-b890-536083f35b46" />
